### PR TITLE
Fix ultralytics minimum version for E2ELoss compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ aiofiles==24.1.0
 httpx==0.28.1
 
 # YOLO and Computer Vision
-ultralytics>=8.3.214  # YOLOv12 requires 8.3.214+
+ultralytics>=8.4.14  # YOLOv10/v11 E2ELoss requires 8.4+
 opencv-python==4.10.0.84
 Pillow==11.0.0
 numpy==1.26.4


### PR DESCRIPTION
## Summary
- Bump ultralytics minimum version from 8.3.214 to 8.4.14
- SAINet_v11.0_e116.pt (YOLO26) requires the `E2ELoss` class, only available in ultralytics 8.4+
- The previous version caused model loading failure and ~15min production downtime on Feb 20

## Test plan
- [x] Verified `E2ELoss` class exists in ultralytics 8.4.14
- [x] Verified model loads correctly after upgrade
- [x] Verified inference works (smoke detected at 83% confidence on test image)
- [x] Production service restored and serving requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)